### PR TITLE
enums: add 2 new definition

### DIFF
--- a/src/enums.rs
+++ b/src/enums.rs
@@ -45,6 +45,8 @@ lazy_static! {
             (0x80000007, "EV_EFI_ACTION"),
             (0x80000008, "EV_EFI_PLATFORM_FIRMWARE_BLOB"),
             (0x80000009, "EV_EFI_HANDOFF_TABLES"),
+            (0x8000000a, "EV_EFI_PLATFORM_FIRMWARE_BLOB2"),
+            (0x8000000b, "EV_EFI_HANDOFF_TABLES2"),
             (0x800000e0, "EV_EFI_VARIABLE_AUTHORITY"),
         ]
     );


### PR DESCRIPTION
EV_EFI_PLATFORM_FIRMWARE_BLOB2 and EV_EFI_HANDOFF_TABLES2 are defined in TCG PC Client Platform Firmware Profile Specification Version 1.05.

EV_EFI_PLATFORM_FIRMWARE_BLOB2 is the replacement for EV_EFI_PLATFORM_FIRMWARE_BLOB EV_EFI_HANDOFF_TABLES2 is the replacement for EV_EFI_HANDOFF_TABLES