### PR TITLE
Fix: Rename RTMR to PCR

### DIFF
--- a/cmd/tdxmeasure/readme.md
+++ b/cmd/tdxmeasure/readme.md
@@ -20,7 +20,7 @@ Log Address:  0x1B10B000
 
 => Read Event Log Data - Address: 0x1B10B000(0x10000)
 ==== TDX Event Log Entry - 0 [0x1B10B000] ====
-RTMR              : 0
+PCR              : 0
 Type              : 3 (EV_NO_ACTION)
 Length            : 65
 Algorithms Number : 1
@@ -33,7 +33,7 @@ RAW DATA: ----------------------------------------------
 1B10B040  00                                               .
 RAW DATA: ----------------------------------------------
 ==== TDX Event Log Entry - 1 [0x1B10B041] ====
-RTMR              : 0
+PCR              : 0
 Type              : 0x8000000B (UNKNOWN)
 Length            : 108
 event             : b'\tTdxTable\x00\x01\x00\x00\x00\x00\x00\x00\x00\xaf\x96\xbb\x93\xf2\xb9\xb8N\x94b\xe0\xbatVB6\x00\x90\x80\x00\x00\x00\x00\x00'

--- a/cmd/tdxmeasure/src/main.rs
+++ b/cmd/tdxmeasure/src/main.rs
@@ -16,7 +16,8 @@ fn main() {
     let data = fs::read(path).unwrap();
 
     let event_log = eventlog_rs::Eventlog::try_from(data).unwrap();
-    let _replayed_rtmr = event_log.replay_measurement_registry();
+    let _replayed_rtmr =
+        event_log.replay_measurement_registry(eventlog_rs::HashAlgorithm::Sha384, |x| x);
 
     println!("{}", event_log);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ impl fmt::Display for Eventlog {
         let mut parsed_el = String::default();
         for event_entry in self.log.clone() {
             parsed_el = format!(
-                "{}\nEvent Entry:\n\tRTMR: {}\n\tEvent Type id: {}\n\tEvent Type: {}\n\tDigest Algorithm: {}\n\tDigest: {}\n\tEvent Desc: {}\n",
+                "{}\nEvent Entry:\n\tPCR: {}\n\tEvent Type id: {}\n\tEvent Type: {}\n\tDigest Algorithm: {}\n\tDigest: {}\n\tEvent Desc: {}\n",
                 parsed_el,
                 event_entry.target_measurement_registry,
                 format!("0x{:08X}", event_entry.event_type_id),
@@ -57,9 +57,9 @@ pub struct ElDigest {
 
 impl Eventlog {
     pub fn replay_measurement_registry(&self) -> HashMap<u32, Vec<u8>> {
-        // result dictionary for classifying event logs by rtmr index
-        // the key is a integer, which represents rtmr index
-        // the value is a list of event log entries whose rtmr index is equal to its related key
+        // result dictionary for classifying event logs by pcr index
+        // the key is a integer, which represents pcr index
+        // the value is a list of event log entries whose pcr index is equal to its related key
         let mut event_logs_by_mr_index: HashMap<u32, Vec<EventlogEntry>> = HashMap::new();
 
         let mut result: HashMap<u32, Vec<u8>> = HashMap::new();


### PR DESCRIPTION
https://trustedcomputinggroup.org/wp-content/uploads/EFI-Protocol-Specification-rev13-160330final.pdf

tdTCG_PCR_EVENT2 marks the first field as PCR rather than RTMR. This patch changes the names and logic from RTMR to PCR.